### PR TITLE
Fix Web accessible resources and permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PouchDB Inspector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "minimum_chrome_version": "10.0",
   "devtools_page": "devtools.html",
   "background": {
@@ -11,11 +11,14 @@
   },
   "permissions": [
     "tabs",
-    "http://*/",
-    "https://*/"
+	"background",
+    "http://*/*",
+    "https://*/*",
+    "<all_urls>"
   ],
   "web_accessible_resources": [
-    "generated/eval.js"
+    "generated/eval.js",
+    "contentscript.js"
   ],
   "manifest_version": 2,
   "icons": {


### PR DESCRIPTION
Fix the bug about "Cannot access contents of url "chrome-devtools://..."
From http://www.codeplats.com/CyVjjXWqeq/chrometabsexecutescript-and-injection-only-into-pages-that-pass-matches-filter-in-manifestjson.html and
